### PR TITLE
front-end translation issue (weeks)

### DIFF
--- a/lib/social/date.php
+++ b/lib/social/date.php
@@ -140,7 +140,7 @@ class Social_Date {
 				return __('1 week', 'social');
 			}
 			else {
-				return sprintf(__('%s weeks', $span['weeks']), $span['weeks']);
+				return sprintf(__('%s weeks', 'social'), $span['weeks']);
 			}
 		}
 
@@ -236,7 +236,7 @@ class Social_Date {
 				return __('1 week ago', 'social');
 			}
 			else {
-				return sprintf(__('%s weeks ago', $span['weeks']), $span['weeks']);
+				return sprintf(__('%s weeks ago', 'social'), $span['weeks']);
 			}
 		}
 


### PR DESCRIPTION
'%s weeks' & '%s weeks ago' were not translated.

Nothing much, juste made
__('%s weeks', $span['weeks']) into __('%s weeks', 'social')
and
__('%s weeks ago', $span['weeks']) into __('%s weeks ago', 'social')
