### PR TITLE
Remove possibility of multiple spaces in the {content} tag

### DIFF
--- a/lib/social/service.php
+++ b/lib/social/service.php
@@ -408,7 +408,7 @@ abstract class Social_Service {
 				case '{content}':
 					$content = do_shortcode($post->post_content);
 					$content = htmlspecialchars_decode(strip_tags($content));
-					$content = trim(preg_replace('(\t+)', ' ', $content));
+					$content = trim(preg_replace('/\t+/', ' ', $content));
 					break;
 				case '{author}':
 					$user = get_userdata($post->post_author);


### PR DESCRIPTION
Hey,

I've been having issues with a site that places gallery shortcodes at the beginning of their posts.

This causes issues with excess whitespace being left after the strip_tags call, making the automatically generated broadcast message require manual editing a majority of the time.

This change fixes that (whilst maintaining linebreaks) and I don't believe will cause any issues with people who don't experience the issue.

Thoughts?

Adrian.
