### PR TITLE
Use esc_url_raw instead of esc_url for sanitizing the url posted

### DIFF
--- a/lib/social/service.php
+++ b/lib/social/service.php
@@ -400,7 +400,7 @@ abstract class Social_Service {
 						$url = home_url('?p='.$post->ID);
 					}
 					$url = apply_filters('social_broadcast_permalink', $url, $post, $this);
-					$content = esc_url($url);
+					$content = esc_url_raw($url);
 					break;
 				case '{title}':
 					$content = htmlspecialchars_decode($post->post_title);


### PR DESCRIPTION
This has the effect, that one can now use entities such as ampersand in the url.
Only works for twitter, not for facebook though. crowdfavorite/wp-social#172
