### PR TITLE
Work around MySQL bug #62077

### DIFF
--- a/lib/social/semaphore.php
+++ b/lib/social/semaphore.php
@@ -162,12 +162,13 @@ final class Social_Semaphore {
 		}
 
 		$current_time = current_time('mysql', 1);
+		$unlock_time = gmdate('Y-m-d H:i:s', time()-30*60);
 		$affected = $wpdb->query($wpdb->prepare("
 			UPDATE $wpdb->options
 			   SET option_value = %s
 			 WHERE option_name = 'social_last_lock_time'
-			   AND option_value <= DATE_SUB(%s, INTERVAL 30 MINUTE)
-		", $current_time, $current_time));
+			   AND option_value <= %s
+		", $current_time, $unlock_time));
 
 		if ($affected == '1') {
 			Social::log('Semaphore was stuck, set lock time to '.$current_time);


### PR DESCRIPTION
The use of DATE_SUB can, depending on the MySQL table's colocation, cause errors like this: "Illegal mix of collations (utf8_general_ci,IMPLICIT) and (latin1_swedish_ci,NUMERIC) for operation '<='". I think this is probably related to MySQL bug #62077 - http://bugs.mysql.com/bug.php?id=62077

In this patch, I've worked around it by doing the date arithmetic in PHP instead. The fix works for me (in my copy of the semaphore library in http://wordpress.org/plugins/updraftplus - I had a user who hit this problem).
